### PR TITLE
Adding Python 2.7 Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@ build/
 dist/
 quinn.egg-info/
 .cache/
-__pycache__/
 tmp/
 .idea/
 .DS_Store
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]

--- a/quinn/dataframe_validator.py
+++ b/quinn/dataframe_validator.py
@@ -13,7 +13,10 @@ class DataFrameProhibitedColumnError(ValueError):
 def validate_presence_of_columns(df, required_col_names):
     all_col_names = df.columns
     missing_col_names = [x for x in required_col_names if x not in all_col_names]
-    error_message = f"The {missing_col_names} columns are not included in the DataFrame with the following columns {all_col_names}"
+    error_message = "The {missing_col_names} columns are not included in the DataFrame with the following columns {all_col_names}".format(
+        missing_col_names=missing_col_names,
+        all_col_names=all_col_names
+    )
     if missing_col_names:
         raise DataFrameMissingColumnError(error_message)
 
@@ -21,7 +24,10 @@ def validate_presence_of_columns(df, required_col_names):
 def validate_schema(df, required_schema):
     all_struct_fields = df.schema
     missing_struct_fields = [x for x in required_schema if x not in all_struct_fields]
-    error_message = f"The {missing_struct_fields} StructFields are not included in the DataFrame with the following StructFields {all_struct_fields}"
+    error_message = "The {missing_struct_fields} StructFields are not included in the DataFrame with the following StructFields {all_struct_fields}".format(
+        missing_struct_fields=missing_struct_fields,
+        all_struct_fields=all_struct_fields
+    )
     if missing_struct_fields:
         raise DataFrameMissingStructFieldError(error_message)
 
@@ -29,6 +35,9 @@ def validate_schema(df, required_schema):
 def validate_absence_of_columns(df, prohibited_col_names):
     all_col_names = df.columns
     extra_col_names = [x for x in all_col_names if x in prohibited_col_names]
-    error_message = f"The {extra_col_names} columns are not allowed to be included in the DataFrame with the following columns {all_col_names}"
+    error_message = "The {extra_col_names} columns are not allowed to be included in the DataFrame with the following columns {all_col_names}".format(
+        extra_col_names=extra_col_names,
+        all_col_names=all_col_names
+    )
     if extra_col_names:
         raise DataFrameProhibitedColumnError(error_message)

--- a/quinn/scala_to_pyspark.py
+++ b/quinn/scala_to_pyspark.py
@@ -52,7 +52,11 @@ class ScalaToPyspark:
             method_name = m.group(2)
             args = m.group(3)
             cleaned_args = self.clean_args(args)
-            return f"{whitespace}def {method_name}({cleaned_args}):\n"
+            return "{whitespace}def {method_name}({cleaned_args}):\n".format(
+                whitespace=whitespace,
+                method_name=method_name,
+                cleaned_args=cleaned_args
+            )
         return s
 
     def clean_args(self, args):

--- a/quinn/transformations.py
+++ b/quinn/transformations.py
@@ -20,5 +20,7 @@ def sort_columns(df, sort_order):
     elif sort_order == "desc":
         sorted_col_names = sorted(df.columns, reverse=True)
     else:
-        raise ValueError(f"['asc', 'desc'] are the only valid sort orders and you entered a sort order of '{sort_order}'")
+        raise ValueError("['asc', 'desc'] are the only valid sort orders and you entered a sort order of '{sort_order}'".format(
+            sort_order=sort_order
+        ))
     return df.select(*sorted_col_names)

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,12 @@
 from setuptools import setup, find_packages
 
-import sys
-if sys.version_info < (3, 0):
-    raise RuntimeError('This version requires Python 3.0+')
-
 install_requires = ['pytest']
 
 tests_require = ['pytest']
 
 setup(
     name='quinn',
-    version='0.2.0',
+    version='0.2.1',
     author='Matthew Powers',
     author_email='matthewkevinpowers@gmail.com',
     url='https://github.com/MrPowers/quinn',
@@ -21,12 +17,17 @@ setup(
     install_requires=install_requires,
     tests_require=tests_require,
     setup_requires=[],
+    python_requires='>=2.7',
     extras_require={
         'test': tests_require,
         'all': install_requires + tests_require,
         'docs': ['sphinx'] + tests_require,
         'lint': []
     },
+    classifiers=[
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6'
+    ],
     dependency_links=[],
     include_package_data=False,
     keywords=['apachespark', 'spark', 'pyspark'],

--- a/tests/extensions/dataframe_transformations.py
+++ b/tests/extensions/dataframe_transformations.py
@@ -22,7 +22,10 @@ def with_jacket(word, df):
 
 @curry
 def with_stuff1(arg1, arg2, df):
-    return df.withColumn("stuff1", lit(f"{arg1} {arg2}"))
+    return df.withColumn(
+        "stuff1",
+        lit("{arg1} {arg2}".format(arg1=arg1, arg2=arg2))
+    )
 
 
 @curry

--- a/tests/test_dataframe_validator.py
+++ b/tests/test_dataframe_validator.py
@@ -19,7 +19,7 @@ class TestDataFrameValidator:
         source_df = spark.createDataFrame(data, ["name", "age"])
         quinn.validate_presence_of_columns(source_df, ["name"])
 
-    def test_validate_schema_when_struct_field_is_missing(self):
+    def test_validate_schema_when_struct_field_is_missing1(self):
         data = [("jose", 1), ("li", 2), ("luisa", 3)]
         source_df = spark.createDataFrame(data, ["name", "age"])
         required_schema = StructType([
@@ -30,7 +30,7 @@ class TestDataFrameValidator:
             quinn.validate_schema(source_df, required_schema)
         assert excinfo.value.args[0] == "The [StructField(city,StringType,true)] StructFields are not included in the DataFrame with the following StructFields StructType(List(StructField(name,StringType,true),StructField(age,LongType,true)))"
 
-    def test_validate_schema_when_struct_field_is_missing(self):
+    def test_validate_schema_when_struct_field_is_missing2(self):
         data = [("jose", 1), ("li", 2), ("luisa", 3)]
         source_df = spark.createDataFrame(data, ["name", "age"])
         required_schema = StructType([


### PR DESCRIPTION
Altering code base to allow python 2.7 compatibility, this mostly just involves
updating formatting to be backward compatible.  All tests are passing on
`Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0` and
`Python 3.6.4, pytest-3.3.2, py-1.5.2, pluggy-0.6.`
Changes include:
* Changing the f-string formatting to use `.format`
* Updated version check to verify a user has at least version 2.7
* Fixed conflicting test names in `tests/test_dataframe_validator.py`
* Upped version to `0.2.1`