### PR TITLE
Include Spark as a Framework in the Classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(
     },
     classifiers=[
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Framework :: Spark :: 2.4.0'
     ],
     dependency_links=[],
     include_package_data=False,


### PR DESCRIPTION
Should you include the Spark Classifier in the setup? It's not standard, but I've seen some projects defining Airflow or other frameworks for docs.