### PR TITLE
[QUINN-16] - Stop importing a default Spark Session

### DIFF
--- a/quinn/extensions/spark_session_ext.py
+++ b/quinn/extensions/spark_session_ext.py
@@ -1,12 +1,10 @@
-from quinn.spark import *
-
 from pyspark.sql.types import StructType, StructField
 from pyspark.sql import SparkSession
 
 
 def create_df(self, rows_data, col_specs):
     struct_fields = list(map(lambda x: StructField(*x), col_specs))
-    return spark.createDataFrame(rows_data, StructType(struct_fields))
+    return self.createDataFrame(data=rows_data, schema=StructType(struct_fields))
 
 
 SparkSession.create_df = create_df

--- a/quinn/functions.py
+++ b/quinn/functions.py
@@ -1,7 +1,4 @@
-from quinn.spark import *
-
 import pyspark.sql.functions as F
-from pyspark.sql.column import Column
 
 from pyspark.sql.types import BooleanType
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ tests_require = ['pytest']
 
 setup(
     name='quinn',
-    version='0.3.0',
+    version='0.3.1',
     author='Matthew Powers',
     author_email='matthewkevinpowers@gmail.com',
     url='https://github.com/MrPowers/quinn',


### PR DESCRIPTION
This PR aims to remove the `from quinn.spark import *` from the extensions and functions helpers avoiding the creation of a SparkSession.