### PR TITLE
QUINN-18 - Provide SparkSession in a class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 language: python
 python:
   - 3.6.7
+cache: pip
 install:
   - pip install -r requirements.txt
   - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
+sudo: false
+dist: trusty
 language: python
 python:
-  - "3.6"
+  - 3.6.7
 install:
   - pip install -r requirements.txt
+  - pip install -e .
 script:
-  - pytest
+  - pytest -v --cov quinn

--- a/quinn/spark.py
+++ b/quinn/spark.py
@@ -1,7 +1,60 @@
+import logging
+import os
+from typing import List
+
+from pyspark import SparkConf
 from pyspark.sql import SparkSession
 
-spark = SparkSession.builder \
-  .master("local") \
-  .appName("quinn") \
-  .getOrCreate()
+STANDALONE = 'local[*]'
 
+
+def quiet_py4j():
+    logger = logging.getLogger('py4j')
+    logger.setLevel(logging.INFO)
+
+
+class SparkProvider:
+
+    def __init__(self,
+                 app_name: str,
+                 conf: SparkConf = None,
+                 extra_dependencies: List[str] = None,
+                 extra_files: List[str] = None):
+        self.spark = self.set_up_spark(app_name, self.master, conf, extra_dependencies, extra_files)
+
+    @property
+    def master(self) -> str:
+        return os.getenv('SPARK_MASTER', STANDALONE)
+
+    @staticmethod
+    def set_up_spark(app_name: str,
+                     master: str = STANDALONE,
+                     conf: SparkConf = None,
+                     extra_dependencies: List[str] = None,
+                     extra_files: List[str] = None) -> SparkSession:
+        conf = conf if conf else SparkConf()
+
+        if extra_dependencies:
+            spark_dependencies = ','.join(extra_dependencies)
+            conf.set('spark.jars.packages', spark_dependencies)
+
+        spark = SparkSession \
+            .builder \
+            .appName(app_name) \
+            .master(master) \
+            .config(conf=conf) \
+            .getOrCreate()
+
+        extra_files = extra_files if extra_files else []
+        for extra_file in extra_files:
+            spark.sparkContext.addPyFile(extra_file)
+
+        quiet_py4j()
+        return spark
+
+    @staticmethod
+    def tear_down_spark(spark):
+        spark.stop()
+        # To avoid Akka rebinding to the same port, since it doesn't unbind
+        # immediately on shutdown
+        spark._jvm.System.clearProperty('spark.driver.port')

--- a/quinn/spark.py
+++ b/quinn/spark.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import List
+from typing import List, Optional
 
 from pyspark import SparkConf
 from pyspark.sql import SparkSession
@@ -17,9 +17,9 @@ class SparkProvider:
 
     def __init__(self,
                  app_name: str,
-                 conf: SparkConf = None,
-                 extra_dependencies: List[str] = None,
-                 extra_files: List[str] = None):
+                 conf: Optional[SparkConf] = None,
+                 extra_dependencies: Optional[List[str]] = None,
+                 extra_files: Optional[List[str]] = None):
         self.spark = self.set_up_spark(app_name, self.master, conf, extra_dependencies, extra_files)
 
     @property

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-pytest==3.2.2
+cytoolz==0.9.0.1
+pytest==3.9.2
+pytest-cov==2.6.0
 #pyspark.egg==info
 setuptools==28.8.0
 pyspark==2.4.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ tests_require = ['pytest']
 
 setup(
     name='quinn',
-    version='0.3.1',
+    version='0.4.0',
     author='Matthew Powers',
     author_email='matthewkevinpowers@gmail.com',
     url='https://github.com/MrPowers/quinn',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 install_requires = ['pytest']
 
-tests_require = ['pytest']
+tests_require = ['pytest', 'pytest-cov']
 
 setup(
     name='quinn',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-install_requires = ['pytest']
+install_requires = ['pytest', 'pytest-cov']
 
 tests_require = ['pytest', 'pytest-cov']
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+from functools import partial
+
+import pytest
+from pyspark import SparkConf
+
+from quinn.spark import SparkProvider
+
+
+# FROM: https://hackebrot.github.io/pytest-tricks/fixtures_as_class_attributes/
+def _inject(cls, names):
+    @pytest.fixture(autouse=True)
+    def auto_injector_fixture(self, request):
+        for name in names:
+            setattr(self, name, request.getfixturevalue(name))
+
+    cls.__auto_injector_fixture = auto_injector_fixture
+    return cls
+
+
+def auto_inject_fixtures(*names):
+    return partial(_inject, names=names)
+
+
+def test_spark_conf() -> SparkConf:
+    return SparkConf() \
+        .set('spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version', 2) \
+        .set('spark.speculation', False) \
+        .set("spark.sql.shuffle.partitions", "1") \
+        .set("spark.ui.enabled", "false")
+
+
+@pytest.fixture(scope='session')
+def spark():
+    spark = SparkProvider.set_up_spark('Testing', 'local[*]', extra_dependencies=[], conf=test_spark_conf())
+    yield spark
+    spark.stop()

--- a/tests/extensions/test_column_ext.py
+++ b/tests/extensions/test_column_ext.py
@@ -1,15 +1,15 @@
-import pytest
-
-from quinn.spark import *
+import pyspark.sql.functions as F
+from pyspark.sql.types import StringType, BooleanType, IntegerType
 from quinn.extensions import *
 
-import pyspark.sql.functions as F
-from pyspark.sql.types import StructType, StructField, StringType, BooleanType, IntegerType, ArrayType
+from tests.conftest import auto_inject_fixtures
 
+
+@auto_inject_fixtures('spark')
 class TestColumnExt:
 
     def test_is_falsy(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                 ("jose", True),
                 ("li", False),
@@ -23,7 +23,7 @@ class TestColumnExt:
 
         actual_df = source_df.withColumn("is_stuff_falsy", F.col("has_stuff").isFalsy())
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [
                 ("jose", True, False),
                 ("li", False, True),
@@ -39,7 +39,7 @@ class TestColumnExt:
         assert expected_df.collect() == actual_df.collect()
 
     def test_is_truthy(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                 ("jose", True),
                 ("li", False),
@@ -53,7 +53,7 @@ class TestColumnExt:
 
         actual_df = source_df.withColumn("is_stuff_truthy", F.col("has_stuff").isTruthy())
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [
                 ("jose", True, True),
                 ("li", False, False),
@@ -69,7 +69,7 @@ class TestColumnExt:
         assert expected_df.collect() == actual_df.collect()
 
     def test_is_false(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                 ("jose", True),
                 ("li", False),
@@ -82,7 +82,7 @@ class TestColumnExt:
         )
         actual_df = source_df.withColumn("is_stuff_false", F.col("has_stuff").isFalse())
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
              [
                 ("jose", True, False),
                 ("li", False, True),
@@ -98,7 +98,7 @@ class TestColumnExt:
         assert expected_df.collect() == actual_df.collect()
 
     def test_is_true(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                 ("jose", True),
                 ("li", False),
@@ -112,7 +112,7 @@ class TestColumnExt:
 
         actual_df = source_df.withColumn("is_stuff_true", F.col("has_stuff").isTrue())
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [
                 ("jose", True, True),
                 ("li", False, False),
@@ -128,7 +128,7 @@ class TestColumnExt:
         assert expected_df.collect() == actual_df.collect()
 
     def test_is_null_or_blank(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                 ("jose", ""),
                 ("li", "   "),
@@ -143,7 +143,7 @@ class TestColumnExt:
 
         actual_df = source_df.withColumn("is_blah_null_or_blank", F.col("blah").isNullOrBlank())
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [
                 ("jose", "", True),
                 ("li", "   ", True),
@@ -160,7 +160,7 @@ class TestColumnExt:
         assert expected_df.collect() == actual_df.collect()
 
     def test_is_not_in(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                 ("jose", "surfing"),
                 ("li", "swimming"),
@@ -176,7 +176,7 @@ class TestColumnExt:
 
         actual_df = source_df.withColumn("is_not_bobs_hobby", F.col("fun_thing").isNotIn(bobs_hobbies))
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [
                 ("jose", "surfing", True),
                 ("li", "swimming", True),
@@ -192,7 +192,7 @@ class TestColumnExt:
         assert expected_df.collect() == actual_df.collect()
 
     def test_null_between(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                  (17, None, 94),
                  (17, None, 10),
@@ -215,7 +215,7 @@ class TestColumnExt:
             F.col("age").nullBetween(F.col("lower_age"), F.col("upper_age"))
         )
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [
                 (17, None, 94, True),
                 (17, None, 10, False),

--- a/tests/extensions/test_spark_session_ext.py
+++ b/tests/extensions/test_spark_session_ext.py
@@ -1,10 +1,9 @@
-import pytest
+from pyspark.sql.types import StructType, StructField, StringType
 
-from quinn.spark import *
-from quinn.extensions import *
+from tests.conftest import auto_inject_fixtures
 
-from pyspark.sql.types import StructType, StructField, StringType, BooleanType
 
+@auto_inject_fixtures('spark')
 class TestSparkSessionExt:
 
     def test_create_df(self):
@@ -13,9 +12,9 @@ class TestSparkSessionExt:
             StructField("blah", StringType(), True)]
         )
         data = [("jose", "a"), ("li", "b"), ("sam", "c")]
-        actual_df = spark.createDataFrame(data, schema)
+        actual_df = self.spark.createDataFrame(data, schema)
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [("jose", "a"), ("li", "b"), ("sam", "c")],
             [("name", StringType(), True), ("blah", StringType(), True)]
         )

--- a/tests/test_assertion_helpers.py
+++ b/tests/test_assertion_helpers.py
@@ -1,18 +1,20 @@
 import pytest
 
-from quinn.spark import *
 import quinn
+from tests.conftest import auto_inject_fixtures
 
+
+@auto_inject_fixtures('spark')
 class TestAssertionHelpers:
 
     def test_assert_column_equality_when_equal(self):
         data = [("jose", 1, 1), ("li", 2, 2), ("luisa", 3, 3)]
-        source_df = spark.createDataFrame(data, ["name", "col1", "col2"])
+        source_df = self.spark.createDataFrame(data, ["name", "col1", "col2"])
         quinn.assert_column_equality(source_df, "col1", "col2")
 
     def test_assert_column_equality_when_different(self):
         data = [("jose", 1, 1), ("li", 2, 2), ("luisa", 3, 5)]
-        source_df = spark.createDataFrame(data, ["name", "col1", "col2"])
+        source_df = self.spark.createDataFrame(data, ["name", "col1", "col2"])
 
         with pytest.raises(quinn.ColumnMismatchError) as excinfo:
             quinn.assert_column_equality(source_df, "col1", "col2")
@@ -20,12 +22,12 @@ class TestAssertionHelpers:
 
     def test_assert_column_equality_equal_with_none(self):
         data = [("jose", None, None), ("li", 2, 2), ("luisa", 3, 3)]
-        source_df = spark.createDataFrame(data, ["name", "col1", "col2"])
+        source_df = self.spark.createDataFrame(data, ["name", "col1", "col2"])
         quinn.assert_column_equality(source_df, "col1", "col2")
 
     def test_assert_column_equality_not_equal_with_none(self):
         data = [("jose", None, 0), ("li", 2, 2), ("luisa", 3, 3)]
-        source_df = spark.createDataFrame(data, ["name", "col1", "col2"])
+        source_df = self.spark.createDataFrame(data, ["name", "col1", "col2"])
 
         with pytest.raises(quinn.ColumnMismatchError) as excinfo:
             quinn.assert_column_equality(source_df, "col1", "col2")
@@ -33,6 +35,5 @@ class TestAssertionHelpers:
 
     def test_assert_column_equality_equal_with_text(self):
         data = [("jose", "", ""), ("li", "student", "student"), ("luisa", "teacher", "teacher")]
-        source_df = spark.createDataFrame(data, ["name", "col1", "col2"])
+        source_df = self.spark.createDataFrame(data, ["name", "col1", "col2"])
         quinn.assert_column_equality(source_df, "col1", "col2")
-

--- a/tests/test_dataframe_helpers.py
+++ b/tests/test_dataframe_helpers.py
@@ -1,13 +1,13 @@
-import pytest
-
-from quinn.spark import *
 import quinn
+from tests.conftest import auto_inject_fixtures
 
+
+@auto_inject_fixtures('spark')
 class TestDataFrameHelpers:
 
     def test_with_age_plus_two(self):
         data = [("jose", 1), ("li", 2), ("luisa", 3)]
-        source_df = spark.createDataFrame(data, ["name", "age"])
+        source_df = self.spark.createDataFrame(data, ["name", "age"])
 
         actual = quinn.column_to_list(source_df, "name")
 
@@ -15,7 +15,7 @@ class TestDataFrameHelpers:
 
     def test_two_columns_to_dictionary(self):
         data = [("jose", 1), ("li", 2), ("luisa", 3)]
-        source_df = spark.createDataFrame(data, ["name", "age"])
+        source_df = self.spark.createDataFrame(data, ["name", "age"])
 
         actual = quinn.two_columns_to_dictionary(source_df, "name", "age")
 
@@ -23,7 +23,7 @@ class TestDataFrameHelpers:
 
     def test_to_list_of_dictionaries(self):
         data = [("jose", 1), ("li", 2), ("luisa", 3)]
-        source_df = spark.createDataFrame(data, ["name", "age"])
+        source_df = self.spark.createDataFrame(data, ["name", "age"])
 
         actual = quinn.to_list_of_dictionaries(source_df)
 

--- a/tests/test_dataframe_validator.py
+++ b/tests/test_dataframe_validator.py
@@ -1,27 +1,28 @@
 import pytest
-
-from quinn.spark import *
-import quinn
-
 from pyspark.sql.types import StructType, StructField, StringType, LongType
 
+import quinn
+from tests.conftest import auto_inject_fixtures
+
+
+@auto_inject_fixtures('spark')
 class TestDataFrameValidator:
 
     def test_validate_presence_of_columns_when_column_is_missing(self):
         data = [("jose", 1), ("li", 2), ("luisa", 3)]
-        source_df = spark.createDataFrame(data, ["name", "age"])
+        source_df = self.spark.createDataFrame(data, ["name", "age"])
         with pytest.raises(quinn.DataFrameMissingColumnError) as excinfo:
             quinn.validate_presence_of_columns(source_df, ["name", "age", "fun"])
         assert excinfo.value.args[0] == "The ['fun'] columns are not included in the DataFrame with the following columns ['name', 'age']"
 
     def test_validate_presence_of_columns_when_all_columns_are_present(self):
         data = [("jose", 1), ("li", 2), ("luisa", 3)]
-        source_df = spark.createDataFrame(data, ["name", "age"])
+        source_df = self.spark.createDataFrame(data, ["name", "age"])
         quinn.validate_presence_of_columns(source_df, ["name"])
 
     def test_validate_schema_when_struct_field_is_missing1(self):
         data = [("jose", 1), ("li", 2), ("luisa", 3)]
-        source_df = spark.createDataFrame(data, ["name", "age"])
+        source_df = self.spark.createDataFrame(data, ["name", "age"])
         required_schema = StructType([
             StructField("name", StringType(), True),
             StructField("city", StringType(), True),
@@ -32,7 +33,7 @@ class TestDataFrameValidator:
 
     def test_validate_schema_when_struct_field_is_missing2(self):
         data = [("jose", 1), ("li", 2), ("luisa", 3)]
-        source_df = spark.createDataFrame(data, ["name", "age"])
+        source_df = self.spark.createDataFrame(data, ["name", "age"])
         required_schema = StructType([
             StructField("name", StringType(), True),
             StructField("age", LongType(), True),
@@ -41,12 +42,12 @@ class TestDataFrameValidator:
 
     def test_validate_absence_of_columns_when_column_is_present(self):
         data = [("jose", 1), ("li", 2), ("luisa", 3)]
-        source_df = spark.createDataFrame(data, ["name", "age"])
+        source_df = self.spark.createDataFrame(data, ["name", "age"])
         with pytest.raises(quinn.DataFrameProhibitedColumnError) as excinfo:
             quinn.validate_absence_of_columns(source_df, ["age", "cool"])
         assert excinfo.value.args[0] == "The ['age'] columns are not allowed to be included in the DataFrame with the following columns ['name', 'age']"
 
     def test_validate_absence_of_columns_when_column_isnt_present(self):
         data = [("jose", 1), ("li", 2), ("luisa", 3)]
-        source_df = spark.createDataFrame(data, ["name", "age"])
+        source_df = self.spark.createDataFrame(data, ["name", "age"])
         quinn.validate_absence_of_columns(source_df, ["favorite_color"])

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,16 +1,16 @@
-import pytest
-
-from quinn.spark import *
-import quinn
-from quinn.extensions import *
-
 from pyspark.sql.functions import col
 from pyspark.sql.types import StructType, StructField, StringType, BooleanType, IntegerType, ArrayType
 
+import quinn
+from quinn.extensions import *
+from tests.conftest import auto_inject_fixtures
+
+
+@auto_inject_fixtures('spark')
 class TestFunctions:
 
     def test_single_space(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                 ("  I like     fish  ", 1),
                 ("    zombies", 2),
@@ -28,7 +28,7 @@ class TestFunctions:
             quinn.single_space(col("words"))
         )
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [
                 ("  I like     fish  ", 1, "I like fish"),
                 ("    zombies", 2, "zombies"),
@@ -45,7 +45,7 @@ class TestFunctions:
         assert expected_df.collect() == actual_df.collect()
 
     def test_remove_all_whitespace(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                 ("  I like     fish  ", 1),
                 ("    zombies", 2),
@@ -63,7 +63,7 @@ class TestFunctions:
             quinn.remove_all_whitespace(col("words"))
         )
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [
                 ("  I like     fish  ", 1, "Ilikefish"),
                 ("    zombies", 2, "zombies"),
@@ -80,7 +80,7 @@ class TestFunctions:
         assert expected_df.collect() == actual_df.collect()
 
     def test_remove_non_word_characters(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                 ("I?like!fish>", 1),
                 ("%%%zombies", 2),
@@ -98,7 +98,7 @@ class TestFunctions:
             quinn.remove_non_word_characters(col("words"))
         )
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [
                 ("I?like!fish>", 1, "Ilikefish"),
                 ("%%%zombies", 2, "zombies"),
@@ -115,7 +115,7 @@ class TestFunctions:
         assert expected_df.collect() == actual_df.collect()
 
     def test_anti_trim(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                 ("  I like     fish  ", 1),
                 ("    zombies", 2),
@@ -133,7 +133,7 @@ class TestFunctions:
             quinn.anti_trim(col("words"))
         )
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [
                 ("  I like     fish  ", 1, "  Ilikefish  "),
                 ("    zombies", 2, "    zombies"),
@@ -150,7 +150,7 @@ class TestFunctions:
         assert expected_df.collect() == actual_df.collect()
 
     def test_exists(self):
-        source_df = spark.createDataFrame(
+        source_df = self.spark.createDataFrame(
             [
                 ("jose", [1, 2, 3]),
                 ("li", [4, 5, 6]),
@@ -167,7 +167,7 @@ class TestFunctions:
             quinn.exists(lambda n: n > 5)(col("nums"))
         )
 
-        expected_df = spark.createDataFrame(
+        expected_df = self.spark.createDataFrame(
             [
                 ("jose", [1, 2, 3], False),
                 ("li", [4, 5, 6], True),
@@ -183,7 +183,7 @@ class TestFunctions:
         assert expected_df.collect() == actual_df.collect()
 
     def test_forall(self):
-        source_df = spark.createDataFrame(
+        source_df = self.spark.createDataFrame(
             [
                 ("jose", [1, 2, 3]),
                 ("li", [4, 5, 6]),
@@ -200,7 +200,7 @@ class TestFunctions:
             quinn.forall(lambda n: n > 3)(col("nums"))
         )
 
-        expected_df = spark.createDataFrame(
+        expected_df = self.spark.createDataFrame(
             [
                 ("jose", [1, 2, 3], False),
                 ("li", [4, 5, 6], True),
@@ -216,7 +216,7 @@ class TestFunctions:
         assert expected_df.collect() == actual_df.collect()
 
     def test_multi_equals(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                 ("cat", "cat"),
                 ("cat", "dog"),
@@ -235,7 +235,7 @@ class TestFunctions:
             quinn.multi_equals("cat")(col("s1"), col("s2"))
         )
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [
                 ("cat", "cat", True),
                 ("cat", "dog", False),

--- a/tests/test_scala_to_pyspark.py
+++ b/tests/test_scala_to_pyspark.py
@@ -1,5 +1,6 @@
 import quinn
 
+
 class TestScalaToPyspark:
 
     def test_clean_args(self):

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -1,12 +1,11 @@
 import pytest
+from pyspark.sql.types import StructType, StructField, StringType
 
-from quinn.spark import *
-from quinn.extensions import *
 import quinn
+from tests.conftest import auto_inject_fixtures
 
-from pyspark.sql.types import StructType, StructField, StringType, BooleanType
 
-
+@auto_inject_fixtures('spark')
 class TestTransformations:
 
     def test_snake_case_col_names(self):
@@ -15,11 +14,11 @@ class TestTransformations:
             StructField("YUMMMMY stuff", StringType(), True)]
         )
         data = [("jose", "a"), ("li", "b"), ("sam", "c")]
-        source_df = spark.createDataFrame(data, schema)
+        source_df = self.spark.createDataFrame(data, schema)
 
         actual_df = quinn.snake_case_col_names(source_df)
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [
                 ("jose", "a"),
                 ("li", "b"),
@@ -34,7 +33,7 @@ class TestTransformations:
         assert expected_df.collect() == actual_df.collect()
 
     def test_sort_columns_asc(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                 ("jose", "oak", "switch"),
                 ("li", "redwood", "xbox"),
@@ -49,7 +48,7 @@ class TestTransformations:
 
         actual_df = quinn.sort_columns(source_df, "asc")
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [
                 ("switch", "jose", "oak"),
                 ("xbox", "li", "redwood"),
@@ -65,7 +64,7 @@ class TestTransformations:
         assert expected_df.collect() == actual_df.collect()
 
     def test_sort_columns_desc(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                 ("jose", "oak", "switch"),
                 ("li", "redwood", "xbox"),
@@ -80,7 +79,7 @@ class TestTransformations:
 
         actual_df = quinn.sort_columns(source_df, "desc")
 
-        expected_df = spark.create_df(
+        expected_df = self.spark.create_df(
             [
                 ("oak", "jose", "switch"),
                 ("redwood", "li", "xbox"),
@@ -96,7 +95,7 @@ class TestTransformations:
         assert expected_df.collect() == actual_df.collect()
 
     def test_sort_columns_exception(self):
-        source_df = spark.create_df(
+        source_df = self.spark.create_df(
             [
                 ("jose", "oak", "switch"),
                 ("li", "redwood", "xbox"),


### PR DESCRIPTION
This PR aims to provide the SparkSession inside a class instead of having a default Spark Session instantiated in `quinn.spark`.

This change should allow developers the issue of instantiating an unhandled spark session by mistake.

Besides, this PR has a proposal to provide the SparkSession as a session fixture to be injected in the desired tests.

What do you think @MrPowers? 