### PR TITLE
Type hints to public methods

### DIFF
--- a/quinn/dataframe_helpers.py
+++ b/quinn/dataframe_helpers.py
@@ -1,17 +1,26 @@
-def column_to_list(df, col_name):
+from typing import Any, Dict, List
+
+from pyspark.sql import DataFrame, SparkSession
+
+
+def column_to_list(df: DataFrame, col_name: str) -> List[Any]:
     return [x[col_name] for x in df.select(col_name).collect()]
 
 
-def two_columns_to_dictionary(df, key_col_name, value_col_name):
+def two_columns_to_dictionary(
+    df: DataFrame, key_col_name: str, value_col_name: str
+) -> Dict[str, Any]:
     k, v = key_col_name, value_col_name
     return {x[k]: x[v] for x in df.select(k, v).collect()}
 
 
-def to_list_of_dictionaries(df):
+def to_list_of_dictionaries(df: DataFrame) -> List[Dict[str, Any]]:
     return list(map(lambda r: r.asDict(), df.collect()))
 
 
-def print_athena_create_table(df, athena_table_name, s3location):
+def print_athena_create_table(
+    df: DataFrame, athena_table_name: str, s3location: str
+) -> None:
     fields = df.schema
 
     print(f"CREATE EXTERNAL TABLE IF NOT EXISTS `{athena_table_name}` ( ")
@@ -26,7 +35,7 @@ def print_athena_create_table(df, athena_table_name, s3location):
     print(f"LOCATION '{s3location}'\n")
 
 
-def show_output_to_df(show_output, spark):
+def show_output_to_df(show_output: str, spark: SparkSession) -> DataFrame:
     l = show_output.split("\n")
     ugly_column_names = l[1]
     pretty_column_names = [i.strip() for i in ugly_column_names[1:-1].split("|")]

--- a/quinn/dataframe_validator.py
+++ b/quinn/dataframe_validator.py
@@ -1,4 +1,8 @@
 import copy
+from typing import List
+
+from pyspark.sql import DataFrame
+from pyspark.sql.types import StructType
 
 
 class DataFrameMissingColumnError(ValueError):
@@ -13,7 +17,7 @@ class DataFrameProhibitedColumnError(ValueError):
     """raise this when a DataFrame includes prohibited columns"""
 
 
-def validate_presence_of_columns(df, required_col_names):
+def validate_presence_of_columns(df: DataFrame, required_col_names: List[str]) -> None:
     all_col_names = df.columns
     missing_col_names = [x for x in required_col_names if x not in all_col_names]
     error_message = "The {missing_col_names} columns are not included in the DataFrame with the following columns {all_col_names}".format(
@@ -23,7 +27,7 @@ def validate_presence_of_columns(df, required_col_names):
         raise DataFrameMissingColumnError(error_message)
 
 
-def validate_schema(df, required_schema, ignore_nullable=False):
+def validate_schema(df: DataFrame, required_schema: StructType, ignore_nullable: bool=False) -> None:
     _all_struct_fields = copy.deepcopy(df.schema)
     _required_schema = copy.deepcopy(required_schema)
 
@@ -43,7 +47,7 @@ def validate_schema(df, required_schema, ignore_nullable=False):
         raise DataFrameMissingStructFieldError(error_message)
 
 
-def validate_absence_of_columns(df, prohibited_col_names):
+def validate_absence_of_columns(df: DataFrame, prohibited_col_names: List[str]) -> None:
     all_col_names = df.columns
     extra_col_names = [x for x in all_col_names if x in prohibited_col_names]
     error_message = "The {extra_col_names} columns are not allowed to be included in the DataFrame with the following columns {all_col_names}".format(

--- a/quinn/extensions/column_ext.py
+++ b/quinn/extensions/column_ext.py
@@ -1,33 +1,34 @@
-from pyspark.sql.functions import when, lit, col, trim
+from typing import Any, List
 
 from pyspark.sql.column import Column
+from pyspark.sql.functions import lit, trim, when
 
 
-def isFalsy(self):
+def isFalsy(self: Column) -> Column:
     return when(self.isNull() | (self == lit(False)), True).otherwise(False)
 
 
-def isTruthy(self):
+def isTruthy(self: Column) -> Column:
     return ~(self.isFalsy())
 
 
-def isFalse(self):
+def isFalse(self: Column) -> Column:
     return self == False
 
 
-def isTrue(self):
+def isTrue(self: Column) -> Column:
     return self == True
 
 
-def isNullOrBlank(self):
+def isNullOrBlank(self: Column) -> Column:
     return (self.isNull()) | (trim(self) == "")
 
 
-def isNotIn(self, list):
+def isNotIn(self: Column, list: List[Any]) -> Column:
     return ~(self.isin(list))
 
 
-def nullBetween(self, lower, upper):
+def nullBetween(self: Column, lower: Column, upper: Column) -> Column:
     return when(lower.isNull() & upper.isNull(), False).otherwise(
         when(self.isNull(), False).otherwise(
             when(lower.isNull() & upper.isNotNull() & (self <= upper), True).otherwise(

--- a/quinn/extensions/dataframe_ext.py
+++ b/quinn/extensions/dataframe_ext.py
@@ -1,7 +1,9 @@
+from typing import Callable
+
 from pyspark.sql.dataframe import DataFrame
 
 
-def transform(self, f):
+def transform(self: DataFrame, f: Callable[[DataFrame], DataFrame]) -> DataFrame:
     return f(self)
 
 

--- a/quinn/extensions/spark_session_ext.py
+++ b/quinn/extensions/spark_session_ext.py
@@ -1,5 +1,5 @@
-from pyspark.sql.types import StructType, StructField
 from pyspark.sql import SparkSession
+from pyspark.sql.types import StructField, StructType
 
 
 def create_df(self, rows_data, col_specs):

--- a/quinn/scala_to_pyspark.py
+++ b/quinn/scala_to_pyspark.py
@@ -1,13 +1,14 @@
 import re
+from typing import List
 
 
 class ScalaToPyspark:
-    def __init__(self, scala_path):
+    def __init__(self: "ScalaToPyspark", scala_path: str) -> None:
         self.scala_path = scala_path
 
-    def lines(self):
-        text_file = open(self.scala_path, "r")
-        result = text_file.readlines()
+    def lines(self: "ScalaToPyspark") -> List[str]:
+        with open(self.scala_path, "r") as text_file:
+            result = text_file.readlines()
 
         # remove lines that start with package
         result = list(filter(lambda l: not l.startswith("package"), result))
@@ -54,10 +55,10 @@ class ScalaToPyspark:
 
         return result
 
-    def display(self):
+    def display(self: "ScalaToPyspark") -> str:
         print("".join(self.lines()))
 
-    def clean_function_definition(self, s):
+    def clean_function_definition(self: "ScalaToPyspark", s: str) -> str:
         m = re.search(r"(\s*)def (\w+).*\((.*)\)", s)
         if m:
             whitespace = m.group(1)
@@ -71,6 +72,6 @@ class ScalaToPyspark:
             )
         return s
 
-    def clean_args(self, args):
+    def clean_args(self: "ScalaToPyspark", args: str) -> str:
         unannoted_args_list = list(map(lambda a: a.split(": ")[0], args.split(", ")))
         return ", ".join(unannoted_args_list)

--- a/quinn/spark.py
+++ b/quinn/spark.py
@@ -15,18 +15,18 @@ def quiet_py4j():
 
 class SparkProvider:
     def __init__(
-        self,
+        self: "SparkProvider",
         app_name: str,
         conf: Optional[SparkConf] = None,
         extra_dependencies: Optional[List[str]] = None,
         extra_files: Optional[List[str]] = None,
-    ):
+    ) -> None:
         self.spark = self.set_up_spark(
             app_name, self.master, conf, extra_dependencies, extra_files
         )
 
     @property
-    def master(self) -> str:
+    def master(self: "SparkProvider") -> str:
         return os.getenv("SPARK_MASTER", STANDALONE)
 
     @staticmethod
@@ -58,7 +58,7 @@ class SparkProvider:
         return spark
 
     @staticmethod
-    def tear_down_spark(spark):
+    def tear_down_spark(spark: SparkSession) -> None:
         spark.stop()
         # To avoid Akka rebinding to the same port, since it doesn't unbind
         # immediately on shutdown

--- a/quinn/transformations.py
+++ b/quinn/transformations.py
@@ -1,8 +1,11 @@
+from typing import Callable
+
 import pyspark.sql.functions as F
+from pyspark.sql import DataFrame
 
 
-def with_columns_renamed(fun):
-    def _(df):
+def with_columns_renamed(fun: Callable[[str], str]) -> Callable[[DataFrame], DataFrame]:
+    def _(df: DataFrame) -> DataFrame:
         cols = list(
             map(
                 lambda col_name: F.col("`{0}`".format(col_name)).alias(fun(col_name)),
@@ -14,7 +17,9 @@ def with_columns_renamed(fun):
     return _
 
 
-def with_some_columns_renamed(fun, change_col_name):
+def with_some_columns_renamed(
+    fun: Callable[[str], str], change_col_name: Callable[[str], str]
+) -> Callable[[DataFrame], DataFrame]:
     def _(df):
         cols = list(
             map(
@@ -29,15 +34,15 @@ def with_some_columns_renamed(fun, change_col_name):
     return _
 
 
-def snake_case_col_names(df):
+def snake_case_col_names(df: DataFrame) -> DataFrame:
     return with_columns_renamed(to_snake_case)(df)
 
 
-def to_snake_case(s):
+def to_snake_case(s: str) -> str:
     return s.lower().replace(" ", "_")
 
 
-def sort_columns(df, sort_order):
+def sort_columns(df: DataFrame, sort_order: str) -> DataFrame:
     sorted_col_names = None
     if sort_order == "asc":
         sorted_col_names = sorted(df.columns)


### PR DESCRIPTION
I added type hints into public methods. I'm not sure about what should I do with `udf`: I can create something like `TypeVar("PythonUDF")` but it won't help anyway and will look messy.


Additionally:
+ Apply isort
+ Apply black

But I can revers it. It is nice to see style configuration inside `pyproject.toml` (for black, isort, flake8, etc.) but now it is missing so I just used default configuration of `black`.

I run all the tests and it passed so looks like there is no syntax errors at leas.

 Changes to be committed:
	modified:   quinn/dataframe_helpers.py
	modified:   quinn/dataframe_validator.py
	modified:   quinn/extensions/column_ext.py
	modified:   quinn/extensions/dataframe_ext.py
	modified:   quinn/extensions/spark_session_ext.py
	modified:   quinn/functions.py
	modified:   quinn/scala_to_pyspark.py
	modified:   quinn/spark.py
	modified:   quinn/transformations.py


Close #61 


P.S. It is my first PR into the project where I'm not an owner and I will be happy to hear any feedback!