### PR TITLE
Fix MKDocs CI/CD

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -33,8 +33,9 @@ jobs:
           poetry install --with mkdocs
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Setup GH
-        run:
-          git config user.name 'github-actions[bot]' && \
+        run: |
+          sudo apt update && sudo apt install -y git
+          git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
       - name: Build and Deploy
         run:


### PR DESCRIPTION
I fixed MKDocs CI/CD and it works now.


CI/CD with fix was successful: https://github.com/MrPowers/quinn/actions/runs/4391780288/jobs/7691152039 
You can see that bot pushed to `gh-action` branch: https://github.com/MrPowers/quinn/tree/gh-pages


@MrPowers You should go to settings of this repository and activate GH Pages. Also you should choose `gh-pages` branch as a source. [There is a short instruction how to do it](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site). Because you are the owner only you can dot it.
 

On branch fix-mkdocs-cicd
 Changes to be committed:
	modified:   .github/workflows/mkdocs.yml

I guess we should also close #5 because we already made a decision about docstrings format.