### PR TITLE
DataFrame#transform method added in Spark 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ __pycache__/
 *.py[cod]
 
 .pytest_cache/
-dump.py

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 *.py[cod]
 
 .pytest_cache/
+dump.py

--- a/quinn/extensions/dataframe_ext.py
+++ b/quinn/extensions/dataframe_ext.py
@@ -7,6 +7,6 @@ def _ext_function(self, f):
         category=DeprecationWarning,
         stacklevel=2
     )
-    return transform(self, f)
+    return f(self)
 
-DataFrame.transform = getattr(DataFrame, "transform", _ext_function)                                  
+DataFrame.transform = getattr(DataFrame, "transform", _ext_function)

--- a/quinn/extensions/dataframe_ext.py
+++ b/quinn/extensions/dataframe_ext.py
@@ -1,10 +1,12 @@
-from typing import Callable
-
+import warnings
 from pyspark.sql.dataframe import DataFrame
 
+def _ext_function(self, f):
+    warnings.warn(
+        "Extensions may be removed in the future versions of quinn. Please use explicit functions instead",
+        category=DeprecationWarning,
+        stacklevel=2
+    )
+    return transform(self, f)
 
-def transform(self: DataFrame, f: Callable[[DataFrame], DataFrame]) -> DataFrame:
-    return f(self)
-
-
-DataFrame.transform = transform
+DataFrame.transform = getattr(DataFrame, "transform", _ext_function)                                  


### PR DESCRIPTION
Added code is tested for PySpark 3.3.2

