### PR TITLE
add quinn.create_df() to address #101

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,24 +279,37 @@ Parses a spark DataFrame output string into a spark DataFrame. Useful for quickl
 +----+---+-----------+------+
 ```
 
+**create_df()**
+
+```python
+data = [("jose", "a"), ("li", "b"), ("sam", "c")]
+schema = [("name", StringType(), True), ("blah", StringType(), True)]
+
+df = quinn.create_df(spark, data, schema)
+```
+
+Creates DataFrame with a syntax that's less verbose than the built-in `createDataFrame` method.
+
+```python
+df.show()
+```
+
+```md
++----+----+
+|name|blah|
++----+----+
+|jose|   a|
+|  li|   b|
+| sam|   c|
++----+----+
+```
+
+
 ## Pyspark Core Class Extensions
 
 ```
 from quinn.extensions import *
 ```
-
-### SparkSession Extensions
-
-**create_df()**
-
-```python
-spark.create_df(
-    [("jose", "a"), ("li", "b"), ("sam", "c")],
-    [("name", StringType(), True), ("blah", StringType(), True)]
-)
-```
-
-Creates DataFrame with a syntax that's less verbose than the built-in `createDataFrame` method.
 
 ### Column Extensions
 

--- a/quinn/dataframe_helpers.py
+++ b/quinn/dataframe_helpers.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List
 
 from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import StructField, StructType
 
 
 def column_to_list(df: DataFrame, col_name: str) -> List[Any]:
@@ -88,3 +89,22 @@ def show_output_to_df(show_output: str, spark: SparkSession) -> DataFrame:
         r = [i.strip() for i in row[1:-1].split("|")]
         pretty_data.append(tuple(r))
     return spark.createDataFrame(pretty_data, pretty_column_names)
+
+
+def create_df(spark: SparkSession, rows_data, col_specs) -> DataFrame:
+    """Creates a new DataFrame from the given data and column specs. The returned
+    DataFrame is created using the StructType and StructField classes provided by
+    PySpark.
+
+    :param spark: SparkSession object
+    :type spark: SparkSession
+    :param rows_data: the data used to create the DataFrame
+    :type rows_data: array-like
+    :param col_specs: list of tuples containing the name and type of the field 
+    :type col_specs: list of tuples
+    :return: a new DataFrame
+    :rtype: DataFrame
+    """
+
+    struct_fields = list(map(lambda x: StructField(*x), col_specs))
+    return spark.createDataFrame(data=rows_data, schema=StructType(struct_fields))

--- a/quinn/extensions/spark_session_ext.py
+++ b/quinn/extensions/spark_session_ext.py
@@ -1,3 +1,4 @@
+import warnings
 from pyspark.sql import SparkSession
 from pyspark.sql.types import StructField, StructType
 
@@ -14,6 +15,13 @@ def create_df(self, rows_data, col_specs):
     :return: a new DataFrame
     :rtype: DataFrame
     """
+
+    warnings.warn(
+        "Extensions in the future versions of quinn. Please use `quinn.create_df()` instead",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
     struct_fields = list(map(lambda x: StructField(*x), col_specs))
     return self.createDataFrame(data=rows_data, schema=StructType(struct_fields))
 

--- a/quinn/extensions/spark_session_ext.py
+++ b/quinn/extensions/spark_session_ext.py
@@ -17,7 +17,7 @@ def create_df(self, rows_data, col_specs):
     """
 
     warnings.warn(
-        "Extensions in the future versions of quinn. Please use `quinn.create_df()` instead",
+        "Extensions may be removed in the future versions of quinn. Please use `quinn.create_df()` instead",
         category=DeprecationWarning,
         stacklevel=2,
     )

--- a/tests/test_dataframe_helpers.py
+++ b/tests/test_dataframe_helpers.py
@@ -1,6 +1,7 @@
 import quinn
 from tests.conftest import auto_inject_fixtures
 import chispa
+from pyspark.sql.types import IntegerType, StringType, StructType, StructField
 
 
 @auto_inject_fixtures("spark")
@@ -66,3 +67,18 @@ def describe_print_athena_create_table():
             out
             == "CREATE EXTERNAL TABLE IF NOT EXISTS `athena_table` ( \n\t `team` string, \n\t `sport` string, \n\t `goals_for` bigint \n)\nSTORED AS PARQUET\nLOCATION 's3://mock'\n\n" # noqa
         )
+
+
+def test_create_df(spark):
+    rows_data = [("jose", 1), ("li", 2), ("luisa", 3)]
+    col_specs = [("name", StringType()), ("age", IntegerType())]
+
+    expected_schema = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("age", IntegerType(), True),
+        ]
+    )
+    actual = quinn.create_df(spark, rows_data, col_specs)
+    expected = spark.createDataFrame(rows_data, expected_schema)
+    chispa.assert_df_equality(actual, expected)


### PR DESCRIPTION
partially addresses #101 

copied the existing create_df from quinn.extensions into quinn/dataframe_helpers and added a quick test to ensure that it creates an equivalent dataframe to spark.createDataFrame()

if this looks good, I can update the readme and replace all instances of spark.create_df() with quinn.create_df() in the repo