### PR TITLE
update business_days_between() to work on older spark versions

### DIFF
--- a/quinn/functions.py
+++ b/quinn/functions.py
@@ -244,10 +244,10 @@ def business_days_between(start_date: Column, end_date: Column) -> Column:
     :returns: a Column with the number of business days between the start and the end date
     :rtype: Column
     """
-    
-    all_days = F.sequence(start_date, end_date)
-    days_of_week = F.transform(all_days, lambda day: F.date_format(day, 'E'))
-    filter_weekends = F.filter(days_of_week, lambda day: day.isNotIn(['Sat','Sun']))
+
+    all_days = "sequence(start_date, end_date)"
+    days_of_week = f"transform({all_days}, x -> date_format(x, 'E'))"
+    filter_weekends = F.expr(f"filter({days_of_week}, x -> x NOT IN ('Sat', 'Sun'))")
     num_business_days = F.size(filter_weekends) - 1
 
     return F.when(num_business_days < 0, None).otherwise(num_business_days)


### PR DESCRIPTION
(hopefully) addresses the failing tests addressed in #114 

I kept the same logic but converted the sql functions to f-strings that get called in the final filter_weekends expression. 

Tests passed on spark 3.0.3 and 3.4.1 on my machine. I was having issues getting 2.4.8 installed. 

I do find the previous code from @fpvmorais more readable - open to alternative suggestions