### PR TITLE
Add random laplace number and div_or_else function

### DIFF
--- a/quinn/math.py
+++ b/quinn/math.py
@@ -1,0 +1,50 @@
+"""Math routines for PySpark."""
+from typing import Optional, Union
+
+from pyspark.sql import Column
+from pyspark.sql import functions as F  # noqa: N812
+
+
+def rand_laplace(
+    mu: Union[float, Column],
+    beta: Union[float, Column],
+    seed: Optional[int] = None,
+) -> Column:
+    """Generate random numbers from Laplace(mu, beta).
+
+    :param mu: mu parameter of Laplace distribution
+    :param beta: beta parameter of Laplace distribution
+    :param seed: random seed value (optional, default None)
+    :returns: column with random numbers
+    """
+    if not isinstance(mu, Column):
+        mu = F.lit(mu)
+
+    if not isinstance(beta, Column):
+        beta = F.lit(beta)
+
+    u = F.rand(seed)
+
+    return (
+        F.when(u < F.lit(0.5), mu + beta * F.log(2 * u))
+        .otherwise(mu - beta * F.log(2 * (1 - u)))
+        .alias("laplace_random")
+    )
+
+
+def div_or_else(
+    cola: Column,
+    colb: Column,
+    default: Union[float, Column] = 0.0,
+) -> Column:
+    """Return result of division of cola by colb or default if colb is zero.
+
+    :param cola: dividend
+    :param colb: divisor
+    :param default: default value
+    :returns: result of division or zero
+    """
+    if not isinstance(default, Column):
+        default = F.lit(default)
+
+    return F.when(colb == F.lit(0.0), default).otherwise(cola / colb)

--- a/quinn/math.py
+++ b/quinn/math.py
@@ -1,4 +1,6 @@
 """Math routines for PySpark."""
+from __future__ import annotations
+
 from typing import Optional, Union
 
 from pyspark.sql import Column


### PR DESCRIPTION
 On branch feature/random-fenerators
 Changes to be committed:
	new file:   quinn/math.py


Related to #88 

I have no idea how to test generation of random numbers without installing `numpy`. But I made few local tests and looks like it works.

1. There is the result of `rand_laplace(mu=-5, beta=4)`:
![laplace_m5_4](https://github.com/MrPowers/quinn/assets/29755009/06f56fde-31a1-4832-ae4d-6df6f0e822f0)

2. There is the result of `rand_laplace(mu=1, beta=2)`:
![laplace_1_2](https://github.com/MrPowers/quinn/assets/29755009/e23ffbb4-1e5f-4804-a9d4-ce043f445959)

And there is how it should look like based on Wiki:
![image](https://github.com/MrPowers/quinn/assets/29755009/5bb6e303-6aee-46d3-8748-72b2c353c627)

One can see that distribution is correct. Also negative mu is processed correctly too.