### PR TITLE
Add templates for feature-request, bug-report, docs-improvement

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report incorrect behavior in the quinn library
 title: "BUG: "
-labels: [Bug, Needs Triage]
+labels: [Bug]
 
 body:
   - type: checkboxes
@@ -28,6 +28,7 @@ body:
         provide a minimal, copy-pastable example.
       placeholder: >
         import quinn
+
 
         quinn.validate_presence_of_columns(source_df, ["name", "age", "fun"])
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug Report
+description: Report incorrect behavior in the quinn library
+title: "BUG: "
+labels: [Bug, Needs Triage]
+
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Quinn version checks
+      options:
+        - label: >
+            I have checked that this issue has not already been reported.
+          required: true
+        - label: >
+            I have confirmed this bug exists on the
+            [latest version](https://pypi.org/project/quinn/) of quinn.
+          required: true
+        - label: >
+            I have confirmed this bug exists on the
+            [main branch](https://github.com/MrPowers/quinn) of quinn.
+  - type: textarea
+    id: example
+    attributes:
+      label: Reproducible Example
+      description: >
+        Please follow [this guide](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) on how to
+        provide a minimal, copy-pastable example.
+      placeholder: >
+        import quinn
+
+        quinn.validate_presence_of_columns(source_df, ["name", "age", "fun"])
+
+        ...
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Issue Description
+      description: >
+        Please provide a description of the issue shown in the reproducible example.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: >
+        Please describe or show a code example of the expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: version
+    attributes:
+      label: Installed Versions
+      description: >
+        Please paste the output of ``quinn.__version__``
+      value: >
+        <details>
+
+        Replace this line with the output of quinn.__version__
+
+        </details>
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/docs_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs_improvement.yml
@@ -10,7 +10,7 @@ body:
       options:
         - label: >
             I have checked that the issue still exists on the latest versions of the docs
-            on `main` [here](https://github.com/MrPowers/quinn)
+            on `main` [here](https://mrpowers.github.io/quinn/)
           required: true
   - type: textarea
     id: location

--- a/.github/ISSUE_TEMPLATE/docs_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs_improvement.yml
@@ -1,0 +1,38 @@
+name: Documentation Improvement
+description: Report wrong or missing documentation
+title: "DOC: "
+labels: [Docs]
+
+body:
+  - type: checkboxes
+    attributes:
+      label: Quinn version checks
+      options:
+        - label: >
+            I have checked that the issue still exists on the latest versions of the docs
+            on `main` [here](https://github.com/MrPowers/quinn)
+          required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Location of the documentation
+      description: >
+        Please provide the location of the documentation, e.g. "quinn.validate_schema()
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Documentation problem
+      description: >
+        Please provide a description of what documentation you believe needs to be fixed/improved
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix for documentation
+      description: >
+        Please explain the suggested fix and **why** it's better than the existing documentation
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature Request
+description: Suggest an idea for pandas
+title: "ENH: "
+labels: [Enhancement]
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Feature Type
+      description: Please check what type of feature request you would like to propose.
+      options:
+        - label: >
+            Adding new functionality to quinn
+        - label: >
+            Changing existing functionality in quinn
+        - label: >
+            Removing existing functionality in quinn
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem Description
+      description: >
+        Please describe what problem the feature would solve, e.g. "I wish I could use quinn to ..."
+    validations:
+      required: true
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature Description
+      description: >
+        Please describe how the new feature would be implemented, using psudocode if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: >
+        Please provide any relevant GitHub issues, code examples or references that help describe and support
+        the feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Suggest an idea for pandas
+description: Suggest an idea for quinn
 title: "ENH: "
 labels: [Enhancement]
 body:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Proposed changes
+
+Describe the big picture of your changes here to communicate to the maintainers. If it fixes a bug or resolves a feature request, please provide a link to that issue.
+
+## Types of changes
+
+What types of changes does your code introduce to quinn?
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation Update (if none of the other choices apply)
+
+## Further comments
+
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Quinn provides DataFrame validation functions, useful column functions / DataFra
 
 ![quinn](https://github.com/MrPowers/quinn/raw/master/quinn.png)
 
+## Documentation
+
+You can find official documentation [here](https://mrpowers.github.io/quinn/).
+
 ## Setup
 
 Quinn is [uploaded to PyPi](https://pypi.org/project/quinn/) and can be installed with this command:


### PR DESCRIPTION
When creating Issue, template will be provided to users to have standardized way of tackling issues and discussion.
closes #164 