### PR TITLE
set ruff version in ci to match `pyproject.toml`

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,3 +12,5 @@ jobs:
           python-version: 3.9
       - name: Run Ruff
         uses: chartboost/ruff-action@v1
+        with: 
+          version: 0.0.291


### PR DESCRIPTION
## Proposed changes

sets a version for ruff in CI to address #187  based on the documentation here https://github.com/ChartBoost/ruff-action



## Types of changes

What types of changes does your code introduce to quinn?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments
