### PR TITLE
Fix surround substring to surround all substrings

### DIFF
--- a/quinn/keyword_finder.py
+++ b/quinn/keyword_finder.py
@@ -111,8 +111,7 @@ def surround_substring(input: str, substring: str, surround_start: str, surround
     :rtype: str
 
     """
-    
     return input.replace(
         substring,
-        surround_start + substring + surround_end
+        surround_start + substring + surround_end,
     )

--- a/quinn/keyword_finder.py
+++ b/quinn/keyword_finder.py
@@ -111,10 +111,8 @@ def surround_substring(input: str, substring: str, surround_start: str, surround
     :rtype: str
 
     """
-    index = input.find(substring)
-    res = ""
-    if index == -1:
-        res = input
-    else:
-        res = input[:index] + surround_start + substring + surround_end + input[(index + len(substring)) :]
-    return res
+    
+    return input.replace(
+        substring,
+        surround_start + substring + surround_end
+    )

--- a/tests/test_keyword_finder.py
+++ b/tests/test_keyword_finder.py
@@ -17,4 +17,9 @@ def test_keyword_format():
 
 
 def test_surround_substring():
-    print(surround_substring("spark rdd stuff", "rdd", "**", "||"))
+
+    assert "spark **rdd|| stuff" == surround_substring("spark rdd stuff", "rdd", "**", "||")
+    assert "spark **rdd|| stuff with **rdd||" == surround_substring("spark rdd stuff with rdd", "rdd", "**", "||")
+    assert "spark **rdd||dd stuff" == surround_substring("spark rdddd stuff", "rdd", "**", "||")
+
+


### PR DESCRIPTION
## Proposed changes

Fixes #209 

## Types of changes

What types of changes does your code introduce to quinn?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

I changed the `input.find`-method to simply use `input.replace` in order to replace all occurrences of the keyword. It will also replace substrings inside words, which I'm not sure is intentional (see 3rd unit test). Should the substring only be surrounded if there are no alphabetical characters, or maybe no alphanumerical characters around it? I.e.
- Current case: 
  - `rdd` in `spark rdd stuff` would be surrounded: `spark **rdd|| stuff`
  - `rdd` in `spark rddrdd stuff` would be surrounded: `spark **rdd||**rdd|| stuff`
  - `rdd` in `spark rdd123 stuff` would be surrounded: `spark **rdd||123 stuff`
- Alphabetical excluded: 
  - `rdd` in `spark rdd stuff` would be surrounded: `spark **rdd|| stuff`
  - `rdd` in `spark rddrdd stuff` would **not** be surrounded: `spark rdd stuff`
  - `rdd` in `spark rdd123 stuff` would be surrounded: `spark **rdd||123 stuff`
- Alphanumerical excluded: 
  - `rdd` in `spark rdd stuff` would be surrounded: `spark **rdd|| stuff`
  - `rdd` in `spark rddrdd stuff` would **not** be surrounded: `spark rddrdd stuff`
  - `rdd` in `spark rdd123 stuff` would **not** be surrounded: `spark rdd123 stuff`