### PR TITLE
Update search files

### DIFF
--- a/quinn/keyword_finder.py
+++ b/quinn/keyword_finder.py
@@ -41,41 +41,50 @@ default_keywords = [
 ]
 
 
-def search_file(path: str, keywords: list[str] = default_keywords) -> None:
+def search_file(path: str, keywords: list[str] = default_keywords) -> dict[str, int]:
     """Searches a file for keywords and prints the line number and line containing the keyword.
 
     :param path: The path to the file to search.
     :type path: str
     :param keywords: The list of keywords to search for.
     :type keywords: list[str]
-    :returns: None
-    :rtype: None
+    :returns: A dictionary containing a file path and the number of lines containing a keyword in `keywords`.
+    :rtype: dict[str, int]
 
     """
+    match_results = {path: 0}
+
     print(f"\nSearching: {path}")
     with open(path) as f:
         for line_number, line in enumerate(f, 1):
             for keyword in keywords:
                 if keyword in line:
                     print(f"{line_number}: {keyword_format(line)}", end="")
-                    break
+                    match_results[path] += 1
+
+    return match_results
 
 
-def search_files(path: str, keywords: list[str] = default_keywords) -> None:
+def search_files(path: str, keywords: list[str] = default_keywords) -> dict[str, int]:
     """Searches all files in a directory for keywords.
 
     :param path: The path to the directory to search.
     :type path: str
     :param keywords: The list of keywords to search for.
     :type keywords: list[str]
-    :returns: None
-    :rtype: None
+    :returns: A dictionary of file paths and the number of lines containing a keyword in `keywords`.
+    :rtype: dict[str, int]
 
     """
     rootdir_glob = f"{path}/**/*"
     file_list = [f for f in iglob(rootdir_glob, recursive=True) if os.path.isfile(f)]
+    match_results = {path: 0 for path in file_list}
+    
     for f in file_list:
-        search_file(f, keywords)
+        file_results = search_file(f, keywords)
+        for path, count in file_results.items():
+            match_results[path] += count
+    return match_results
 
 
 def keyword_format(input: str, keywords: list[str] = default_keywords) -> str:

--- a/quinn/keyword_finder.py
+++ b/quinn/keyword_finder.py
@@ -41,7 +41,7 @@ default_keywords = [
 ]
 
 
-def search_file(path: str, keywords: list[str] = default_keywords) -> dict[str, int]:
+def search_file(path: str, keywords: list[str] = default_keywords) -> dict[str, dict[str, int]]:
     """Searches a file for keywords and prints the line number and line containing the keyword.
 
     :param path: The path to the file to search.
@@ -49,7 +49,7 @@ def search_file(path: str, keywords: list[str] = default_keywords) -> dict[str, 
     :param keywords: The list of keywords to search for.
     :type keywords: list[str]
     :returns: A dictionary containing a file path and the number of lines containing a keyword in `keywords`.
-    :rtype: dict[str, int]
+    :rtype: dict[str, dict[str, int]]
 
     """
     match_results = {path: {keyword: 0 for keyword in keywords}}
@@ -60,7 +60,7 @@ def search_file(path: str, keywords: list[str] = default_keywords) -> dict[str, 
             line_printed = False
             for keyword in keywords:
                 if keyword in line:
-                    match_results[path][keyword] += 1 
+                    match_results[path][keyword] += 1
 
                     if not line_printed:
                         print(f"{line_number}: {keyword_format(line)}", end="")
@@ -77,7 +77,7 @@ def search_files(path: str, keywords: list[str] = default_keywords) -> dict[str,
     :param keywords: The list of keywords to search for.
     :type keywords: list[str]
     :returns: A dictionary of file paths and the number of lines containing a keyword in `keywords`.
-    :rtype: dict[str, int]
+    :rtype: dict[str, dict[str, int]]
 
     """
     rootdir_glob = f"{path}/**/*"

--- a/quinn/keyword_finder.py
+++ b/quinn/keyword_finder.py
@@ -52,20 +52,19 @@ def search_file(path: str, keywords: list[str] = default_keywords) -> dict[str, 
     :rtype: dict[str, int]
 
     """
-    match_results = {path: 0}
+    match_results = {path: {keyword: 0 for keyword in keywords}}
 
     print(f"\nSearching: {path}")
     with open(path) as f:
         for line_number, line in enumerate(f, 1):
             for keyword in keywords:
                 if keyword in line:
-                    print(f"{line_number}: {keyword_format(line)}", end="")
-                    match_results[path] += 1
+                    match_results[path][keyword] += 1 
 
     return match_results
 
 
-def search_files(path: str, keywords: list[str] = default_keywords) -> dict[str, int]:
+def search_files(path: str, keywords: list[str] = default_keywords) -> dict[str, dict[str, int]]:
     """Searches all files in a directory for keywords.
 
     :param path: The path to the directory to search.
@@ -78,12 +77,11 @@ def search_files(path: str, keywords: list[str] = default_keywords) -> dict[str,
     """
     rootdir_glob = f"{path}/**/*"
     file_list = [f for f in iglob(rootdir_glob, recursive=True) if os.path.isfile(f)]
-    match_results = {path: 0 for path in file_list}
-    
+    match_results = {path: {keyword: 0 for keyword in keywords} for path in file_list}
+
     for f in file_list:
         file_results = search_file(f, keywords)
-        for path, count in file_results.items():
-            match_results[path] += count
+        match_results.update(file_results)
     return match_results
 
 

--- a/quinn/keyword_finder.py
+++ b/quinn/keyword_finder.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from glob import iglob
-from typing import TypedDict
 
 default_keywords = [
     "_jsc",
@@ -41,8 +41,8 @@ default_keywords = [
     "sparkContext",
 ]
 
-
-class SearchResult(TypedDict):
+@dataclass
+class SearchResult:
     """Class to hold the results of a file search.
     file_path: The path to the file that was searched.
     word_count: A dictionary containing the number of times each keyword was found in the file.
@@ -63,7 +63,7 @@ def search_file(path: str, keywords: list[str] = default_keywords) -> SearchResu
     :rtype: SearchResult
 
     """
-    match_results: SearchResult = {"file_path": path, "word_count": {keyword: 0 for keyword in keywords}}
+    match_results = SearchResult(file_path=path, word_count={keyword: 0 for keyword in keywords})
 
     print(f"\nSearching: {path}")
     with open(path) as f:
@@ -71,7 +71,7 @@ def search_file(path: str, keywords: list[str] = default_keywords) -> SearchResu
             line_printed = False
             for keyword in keywords:
                 if keyword in line:
-                    match_results["word_count"][keyword] += 1
+                    match_results.word_count[keyword] += 1
 
                     if not line_printed:
                         print(f"{line_number}: {keyword_format(line)}", end="")

--- a/quinn/keyword_finder.py
+++ b/quinn/keyword_finder.py
@@ -57,9 +57,14 @@ def search_file(path: str, keywords: list[str] = default_keywords) -> dict[str, 
     print(f"\nSearching: {path}")
     with open(path) as f:
         for line_number, line in enumerate(f, 1):
+            line_printed = False
             for keyword in keywords:
                 if keyword in line:
                     match_results[path][keyword] += 1 
+
+                    if not line_printed:
+                        print(f"{line_number}: {keyword_format(line)}", end="")
+                        line_printed = True
 
     return match_results
 

--- a/tests/test_keyword_finder.py
+++ b/tests/test_keyword_finder.py
@@ -5,16 +5,19 @@ def test_search_file():
     file_path = "tests/test_files/some_pyspark.py"
     results = search_file(file_path)
 
-    assert results[file_path]["rdd"] == 5
-    assert results[file_path]["sparkContext"] == 2
+    assert results["word_count"]["rdd"] == 5
+    assert results["word_count"]["sparkContext"] == 2
 
 
 def test_search_files():
     results = search_files("tests/test_files")
 
-    assert results["tests/test_files/some_pyspark.py"]["rdd"] == 5
-    assert results["tests/test_files/some_pyspark.py"]["sparkContext"] == 2
-    assert results["tests/test_files/good_schema1.csv"]["rdd"] == 0
+    pyspark_file = [result for result in results if result["file_path"] == "tests/test_files/some_pyspark.py"][0]
+    csv_file = [result for result in results if result["file_path"] == "tests/test_files/good_schema1.csv"][0]
+
+    assert pyspark_file["word_count"]["rdd"] == 5
+    assert pyspark_file["word_count"]["sparkContext"] == 2
+    assert csv_file["word_count"]["rdd"] == 0
 
 
 def test_keyword_format():
@@ -29,5 +32,3 @@ def test_surround_substring():
     assert "spark **rdd|| stuff" == surround_substring("spark rdd stuff", "rdd", "**", "||")
     assert "spark **rdd|| stuff with **rdd||" == surround_substring("spark rdd stuff with rdd", "rdd", "**", "||")
     assert "spark **rdd||dd stuff" == surround_substring("spark rdddd stuff", "rdd", "**", "||")
-
-

--- a/tests/test_keyword_finder.py
+++ b/tests/test_keyword_finder.py
@@ -5,19 +5,19 @@ def test_search_file():
     file_path = "tests/test_files/some_pyspark.py"
     results = search_file(file_path)
 
-    assert results["word_count"]["rdd"] == 5
-    assert results["word_count"]["sparkContext"] == 2
+    assert results.word_count["rdd"] == 5
+    assert results.word_count["sparkContext"] == 2
 
 
 def test_search_files():
     results = search_files("tests/test_files")
 
-    pyspark_file = [result for result in results if result["file_path"] == "tests/test_files/some_pyspark.py"][0]
-    csv_file = [result for result in results if result["file_path"] == "tests/test_files/good_schema1.csv"][0]
+    pyspark_file = [result for result in results if result.file_path == "tests/test_files/some_pyspark.py"][0]
+    csv_file = [result for result in results if result.file_path == "tests/test_files/good_schema1.csv"][0]
 
-    assert pyspark_file["word_count"]["rdd"] == 5
-    assert pyspark_file["word_count"]["sparkContext"] == 2
-    assert csv_file["word_count"]["rdd"] == 0
+    assert pyspark_file.word_count["rdd"] == 5
+    assert pyspark_file.word_count["sparkContext"] == 2
+    assert csv_file.word_count["rdd"] == 0
 
 
 def test_keyword_format():

--- a/tests/test_keyword_finder.py
+++ b/tests/test_keyword_finder.py
@@ -3,16 +3,18 @@ from quinn.keyword_finder import search_file, search_files, keyword_format, surr
 
 def test_search_file():
     file_path = "tests/test_files/some_pyspark.py"
-    
     results = search_file(file_path)
-    assert results[file_path] == 8
+
+    assert results[file_path]["rdd"] == 5
+    assert results[file_path]["sparkContext"] == 2
 
 
 def test_search_files():
     results = search_files("tests/test_files")
 
-    assert results["tests/test_files/some_pyspark.py"] == 8
-    assert results["tests/test_files/good_schema1.csv"] == 0
+    assert results["tests/test_files/some_pyspark.py"]["rdd"] == 5
+    assert results["tests/test_files/some_pyspark.py"]["sparkContext"] == 2
+    assert results["tests/test_files/good_schema1.csv"]["rdd"] == 0
 
 
 def test_keyword_format():

--- a/tests/test_keyword_finder.py
+++ b/tests/test_keyword_finder.py
@@ -2,11 +2,17 @@ from quinn.keyword_finder import search_file, search_files, keyword_format, surr
 
 
 def test_search_file():
-    search_file("tests/test_files/some_pyspark.py")
+    file_path = "tests/test_files/some_pyspark.py"
+    
+    results = search_file(file_path)
+    assert results[file_path] == 8
 
 
 def test_search_files():
-    search_files("tests/test_files")
+    results = search_files("tests/test_files")
+
+    assert results["tests/test_files/some_pyspark.py"] == 8
+    assert results["tests/test_files/good_schema1.csv"] == 0
 
 
 def test_keyword_format():


### PR DESCRIPTION
## Proposed changes

Adds feature described in #214 

## Types of changes

What types of changes does your code introduce to quinn?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

Added dictionary result of {path: {keyword: count}}. Can change schema if needed. 

During testing, I noticed the counts of the keywords weren't accurate because of the `break` command after the first keyword  was found per line. For example, this test returned an "rdd" count of 4 because of the multiple matches on line 8
![image](https://github.com/MrPowers/quinn/assets/42007840/3fd80600-d577-41f0-a473-9059b352d71b)

I assumed this was to prevent printing the same line more than once, so I removed `break` and added a check to only print the line the first time with `line_printed` starting at False and updating to True after a keyword match. 