### PR TITLE
Fix: Failure in tests/extensions/test_dataframe_ext.py for Spark 2.4

### DIFF
--- a/tests/extensions/test_dataframe_ext.py
+++ b/tests/extensions/test_dataframe_ext.py
@@ -1,5 +1,6 @@
 from functools import partial
-
+import pytest
+import pyspark
 import chispa
 from pyspark.sql.functions import col
 
@@ -29,6 +30,7 @@ def test_verbose_code_without_transform():
     chispa.assert_df_equality(df2, expected_df, ignore_nullable=True)
 
 
+@pytest.mark.skipif(pyspark.__version__ < '3.0', reason="df.transform not available for Spark<3.0")
 def test_transform_with_lambda():
     data = [("jose", 1), ("li", 2), ("liz", 3)]
     source_df = spark.createDataFrame(data, ["name", "age"])
@@ -40,6 +42,7 @@ def test_transform_with_lambda():
     chispa.assert_df_equality(actual_df, expected_df)
 
 
+@pytest.mark.skipif(pyspark.__version__ < '3.0', reason="df.transform not available for Spark<3.0")
 def test_transform_with_no_arg_fun():
     data = [("jose", 1), ("li", 2), ("liz", 3)]
     source_df = spark.createDataFrame(data, ["name", "age"])
@@ -49,6 +52,7 @@ def test_transform_with_no_arg_fun():
     chispa.assert_df_equality(actual_df, expected_df, ignore_nullable=True)
 
 
+@pytest.mark.skipif(pyspark.__version__ < '3.0', reason="df.transform not available for Spark<3.0")
 def test_transform_with_one_arg_fun():
     data = [("jose", 1), ("li", 2), ("liz", 3)]
     source_df = spark.createDataFrame(data, ["name", "age"])
@@ -58,6 +62,7 @@ def test_transform_with_one_arg_fun():
     chispa.assert_df_equality(actual_df, expected_df, ignore_nullable=True)
 
 
+@pytest.mark.skipif(pyspark.__version__ < '3.0', reason="df.transform not available for Spark<3.0")
 def test_chain_transforms():
     data = [("jose", 1), ("li", 2), ("liz", 3)]
     source_df = spark.createDataFrame(data, ["name", "age"])
@@ -75,6 +80,7 @@ def test_chain_transforms():
     chispa.assert_df_equality(actual_df, expected_df, ignore_nullable=True)
 
 
+@pytest.mark.skipif(pyspark.__version__ < '3.0', reason="df.transform not available for Spark<3.0")
 def test_transform_with_closure():
     data = [("jose", 1), ("li", 2), ("liz", 3)]
     source_df = spark.createDataFrame(data, ["name", "age"])
@@ -92,6 +98,7 @@ def test_transform_with_closure():
     chispa.assert_df_equality(actual_df, expected_df, ignore_nullable=True)
 
 
+@pytest.mark.skipif(pyspark.__version__ < '3.0', reason="df.transform not available for Spark<3.0")
 def test_transform_with_functools_partial():
     data = [("jose", 1), ("li", 2), ("liz", 3)]
     source_df = spark.createDataFrame(data, ["name", "age"])


### PR DESCRIPTION
## Proposed changes

Added skipif marker to few tests containing df.transform() as this method was only introduced in Spark 3.0, fixes test failure for pyspark < 3.0. Fixes #216. 

## Types of changes

What types of changes does your code introduce to quinn?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

Minor, non-breaking change introduced with a pytest skipif marker so that nothing breaks on the tests even after we decommission support for PySpark < 3.0.