### PR TITLE
Add maintainers to pyproject.toml & update CONTRIBUTING.md with ruff setup for IDEs (#173 and #163)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,8 +124,3 @@ When you're finished with the changes, create a pull request, also known as a PR
 - Don't forget to link PR to the issue if you are solving one.
 - As you update your PR and apply changes, mark each conversation as resolved.
 - If you run into any merge issues, checkout this [git tutorial](https://github.com/skills/resolve-merge-conflicts) to help you resolve merge conflicts and other issues.
-
-## Maintainers and Reviewers
-
-1. [MrPowers](https://github.com/MrPowers)
-2. ...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,11 +74,49 @@ This project follows the [PySpark style guide](https://github.com/MrPowers/spark
 """
 ```
 
-We are using `isort`, `black` and `ruff` as linters. You can find instructions on how to set up and use these tools here:
+We are using `isort` and `ruff` as linters. You can find instructions on how to set up and use these tools here:
 
 1. [isort](https://pycqa.github.io/isort/)
-2. [black](https://black.readthedocs.io/en/stable/)
-3. [ruff](https://github.com/charliermarsh/ruff)
+2. [ruff](https://github.com/charliermarsh/ruff)
+
+### Adding ruff to IDEs
+
+#### VSCode
+
+1. Install the `Ruff` extension by Astral Software from the VSCode marketplace (Extension ID: *charliermarsh.ruff*).
+2. Open the command palette (Ctrl+Shift+P) and select `Preferences: Open Settings (JSON)`.
+3. Add the following configuration to your settings.json file:
+
+```json
+{
+    "python.linting.ruffEnabled": true,
+    "python.linting.enabled": true,
+    "python.formatting.provider": "none",
+    "editor.formatOnSave": true
+}
+```
+The above settings will enable linting with Ruff, and format your code with Ruff on save.
+
+#### PyCharm
+
+To set up `Ruff` in PyCharm using `poetry`, follow these steps:
+
+1. **Find the path to your `poetry` executable:**
+   - Open a terminal.
+   - For macOS/Linux, use the command `which poetry`.
+   - For Windows, use the command `where poetry`.
+   - Note down the path returned by the command.
+
+2. **Open the `Preferences` window** (Cmd+, on macOS).
+3. **Navigate to `Tools` > `External Tools`.**
+4. **Click the `+` icon** to add a new external tool.
+5. **Fill in the following details:**
+   - **Name:** `Ruff`
+   - **Program:** Enter the path to your `poetry` executable that you noted earlier.
+   - **Arguments:** `run ruff check --fix $FilePathRelativeToProjectRoot$`
+   - **Working directory:** `$ProjectFileDir$`
+6. **Click `OK`** to save the configuration.
+7. **To run Ruff,** right-click on a file or directory in the project view, select `External Tools`, and then select `Ruff`.
 
 ### Pull Request
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,12 @@ name = "quinn"
 version = "0.10.3"
 description = "Pyspark helper methods to maximize developer efficiency"
 authors = ["MrPowers <matthewkevinpowers@gmail.com>"]
+
+# Maintainers of the project
+maintainers = [
+    "SemyonSinchenko <ssinchenko@apache.org>"
+]
+
 readme = "README.md"
 homepage = "https://github.com/MrPowers/quinn/"
 keywords = ['apachespark', 'spark', 'pyspark']


### PR DESCRIPTION
## Proposed changes

**Related to #173, add maintainers to `pyproject.toml` file**

* Add a `maintainers` section below the `authors` section.
* Include the names and contact information of the maintainers (first version only).
* Use the format `name <email>` for each maintainer.
* Add a comment above the `maintainers` section to indicate its purpose.

**Related to #163, following changes have been made in the file:**

* Remove mention of Black from the CONTRIBUTING.md
* Add instructions on how to add ruff to VSCode
* Add instructions on how to add ruff to PyCharm


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Further comments
* Since I was working on two issues and merged them to the main branch on the repo I forked, both the changes have started to appear in this PR. Hence, closes the issues #163  and #173 .
* Regarding the maintainers update, I have added only @SemyonSinchenko to the maintainers list for now. Please let me know if any others should be added to the list in this same PR. PR checks/GitHub actions have passed when I tried merging to my `master/main` branch. Kindly review & merge.