### PR TITLE
Fix docstring for anti_trim function

### DIFF
--- a/quinn/functions.py
+++ b/quinn/functions.py
@@ -60,11 +60,11 @@ def remove_all_whitespace(col: Column) -> Column:
 
 
 def anti_trim(col: Column) -> Column:
-    """Remove whitespace from the boundaries of ``col`` using the regexp_replace function.
+    """Remove all inner whitespace but retain leading and trailing whitespace.
 
     :param col: Column on which to perform the regexp_replace.
     :type col: Column
-    :return: A new Column with all whitespace removed from the boundaries.
+    :return: A new Column with all inner whitespace removed but leading and trailing whitespace retained.
     :rtype: Column
     """
     return F.regexp_replace(col, "\\b\\s+\\b", "")


### PR DESCRIPTION
## Proposed changes

Related to #227

Update the docstring for the `anti_trim` function to correctly describe its behavior.
* Change the docstring to state that the function removes all inner whitespace but retains leading and trailing whitespace.

## Types of changes

- [x] Documentation Update (if none of the other choices apply)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments
N/A.