### PR TITLE
Fix git command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,9 @@ To start contributing you should fork this repository and only after that clone 
 
 ```shell
 # for user-login
-git remote --set-url origin https://github.com/your-github-name/quinn.git
+git remote set-url origin https://github.com/your-github-name/quinn.git
 # for private keys way
-git remote --set-url origin git@github.com:your-github-name/quinn.git
+git remote set-url origin git@github.com:your-github-name/quinn.git
 ```
 
 ### Install the project


### PR DESCRIPTION
## Proposed changes

This PR is related to #234. Updates the git command in CONTRIBUTING.md file.

* Change `git remote --set-url` to `git remote set-url` for setting the URL for the origin.
* Ensure the command is correct and does not produce an error.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Further comments
* This closes the issue #234 