### PR TITLE
Improve documentation of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,36 +3,31 @@
 all: help
 
 .PHONY: install_test
-install_test:
+install_test: ## Install test dependencies
 	@poetry install --with=development,testing
 
 .PHONY: install_deps
-install_deps:
+install_deps: ## Install all dependencies
 	@poetry install --with=development,linting,testing,docs
 
 .PHONY: update_deps
-update_deps:
+update_deps: ## Update dependencies
 	@poetry update --with=development,linting,testing,docs
 
 .PHONY: test
-test:
+test: ## Run the unit tests
 	@poetry run pytest tests
 
 .PHONY: lint 
-lint:
+lint: ## Lint the code
 	@poetry run ruff check --fix quinn
 
 .PHONY: format
-format:
+format: ## Format the code
 	@poetry run ruff format quinn
 
 .PHONY: help
-help:
-	@echo '................... Quin ..........................'
-	@echo 'help                      - print that message'
-	@echo 'lint                      - run linter'
-	@echo 'format                    - reformat the code'
-	@echo 'test                      - run tests'
-	@echo 'install_test              - install test deps'
-	@echo 'install_deps              - install dev deps'
-	@echo 'update_deps               - update and install deps'
+help: ## Show help for the commands.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ lint: ## Lint the code
 format: ## Format the code
 	@poetry run ruff format quinn
 
+# Inspired by https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 .PHONY: help
 help: ## Show help for the commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ format: ## Format the code
 	@poetry run ruff format quinn
 
 .PHONY: help
-help: ## Show help for the commands.
+help: ## Show help for the commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 .DEFAULT_GOAL := help


### PR DESCRIPTION
## Proposed changes

Improve documentation of Makefile to reduce risk of the `make help` command running out of sync with the actual commands in the future. Running `make help` will show:

```
install_test         Install test dependencies
install_deps         Install all dependencies
update_deps          Update dependencies
test                 Run the unit tests
lint                 Lint the code
format               Format the code
help                 Show help for the commands.
```