### PR TITLE
Enforce ruff linting on commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,8 @@ repos:
     rev: 'v0.0.291'
     hooks:
       - id: ruff
+        args: [--exit-non-zero-on-fix]
+      - id: ruff-format
   - repo: local
     hooks:
       - id: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
-      - id: ruff-format
   - repo: local
     hooks:
       - id: pytest


### PR DESCRIPTION
## Proposed changes

Addresses issue #268 by enforcing ruff linting on pre-commit hooks.

## Types of changes

What types of changes does your code introduce to quinn?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
